### PR TITLE
date: Copy all headers always

### DIFF
--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -22,7 +22,6 @@ class DateConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "header_only": [True, False],
-        "install_all_headers" : [True, False],
         "use_system_tz_db": [True, False],
         "use_tz_db_in_dot": [True, False],
     }
@@ -30,7 +29,6 @@ class DateConan(ConanFile):
         "shared": False,
         "fPIC": True,
         "header_only": False,
-        "install_all_headers" : False,
         "use_system_tz_db": False,
         "use_tz_db_in_dot": False,
     }
@@ -93,19 +91,13 @@ class DateConan(ConanFile):
 
     def package(self):
         copy(self, "LICENSE.txt", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
-        src = os.path.join(self.source_folder, "include", "date")
-        dst = os.path.join(self.package_folder, "include", "date")
-        if self.options.header_only:
-            for header_file in ["date.h", "tz.h", "ptz.h", "iso_week.h", "julian.h", "islamic.h"]:
-                copy(self, header_file, dst=dst, src=src)
-        else:
+        if not self.options.header_only:
             cmake = CMake(self)
             cmake.install()
             rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
             rmdir(self, os.path.join(self.package_folder, "CMake"))
-            if self.options.install_all_headers:
-                for header_file in ["ptz.h", "iso_week.h", "julian.h", "islamic.h"]:
-                    copy(self, header_file, dst=dst, src=src)
+        copy(self, "*.h", dst=os.path.join(self.package_folder, "include", "date"),
+                src=os.path.join(self.source_folder, "include", "date"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "date")


### PR DESCRIPTION
PR review related to https://github.com/conan-io/conan-center-index/pull/24998

After discussing with Conan team and checking other package manager, it would be better copying all headers always, so we do not need to add a new option and affect the package ID.

